### PR TITLE
Fix: add ComputePool.Status custom UnmarshalJSON for flat API response

### DIFF
--- a/v1/.openapi-generator-ignore
+++ b/v1/.openapi-generator-ignore
@@ -23,7 +23,6 @@
 #!docs/README.md
 
 # Custom unmarshaler for ComputePool.Status (and its tests) that handles the
-# flat API response shape. Remove both entries once the OpenAPI spec uses
-# $ref to ComputePoolStatus instead of an inline definition.
+# flat API response shape.
 model_compute_pool_custom.go
 model_compute_pool_custom_test.go

--- a/v1/.openapi-generator-ignore
+++ b/v1/.openapi-generator-ignore
@@ -21,3 +21,9 @@
 #docs/*.md
 # Then explicitly reverse the ignore rule for a single file:
 #!docs/README.md
+
+# Custom unmarshaler for ComputePool.Status (and its tests) that handles the
+# flat API response shape. Remove both entries once the OpenAPI spec uses
+# $ref to ComputePoolStatus instead of an inline definition.
+model_compute_pool_custom.go
+model_compute_pool_custom_test.go

--- a/v1/model_compute_pool_custom.go
+++ b/v1/model_compute_pool_custom.go
@@ -6,10 +6,9 @@ import (
 	"fmt"
 )
 
-// UnmarshalJSON handles ComputePool.Status when the API returns a flat object
-// (e.g. {"phase":"RUNNING"}). The generated type *map[string]map[string]interface{}
-// cannot hold scalar values directly, so every value in the status object is
-// wrapped as {"value": v}. Non-object status shapes (array, scalar) surface a
+// UnmarshalJSON wraps every value in ComputePool.Status as {"value": v} so the
+// CMF API's flat status object (e.g. {"phase":"RUNNING"}) fits the generated
+// type *map[string]map[string]interface{}. Non-object status shapes surface a
 // decode error rather than being silently dropped.
 func (o *ComputePool) UnmarshalJSON(data []byte) error {
 	// Alias strips methods so the inner decode doesn't re-enter UnmarshalJSON.
@@ -21,7 +20,7 @@ func (o *ComputePool) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
 	}
-	o.Status = nil // reset for receiver reuse; repopulated below on success
+	o.Status = nil // reset for receiver reuse
 	if len(aux.Status) == 0 || bytes.Equal(aux.Status, []byte("null")) {
 		return nil
 	}

--- a/v1/model_compute_pool_custom.go
+++ b/v1/model_compute_pool_custom.go
@@ -5,63 +5,35 @@ import (
 	"encoding/json"
 )
 
-// UnmarshalJSON is a custom unmarshaler that makes ComputePool.Status
-// deserialize correctly against the real CMF API response.
-//
-// The generated type declares Status as *map[string]map[string]interface{}
-// (due to an inline OpenAPI schema with additionalProperties: true), but the
-// API returns a flat object like {"phase":"RUNNING","message":null}. The
-// standard encoding/json decode fails on that shape because scalar values
-// cannot fit into map[string]interface{}.
-//
-// To conform to the declared type, each scalar (or null) value in the status
-// object is wrapped as {"value": <value>}; values that are already objects
-// are passed through unchanged to avoid double-wrapping. Callers can then
-// read fields uniformly via pool.GetStatus()["<key>"]["value"] for scalars,
-// or traverse the nested object directly.
-//
-// Status shapes that are neither null nor a JSON object (e.g. an array,
-// string, or number at the top level) are treated as absent — Status is set
-// to nil rather than failing the whole response deserialization, since the
-// whole point of this unmarshaler is to keep Execute() succeeding on valid
-// 200 responses.
-//
-// TODO: remove this file and its entries in v1/.openapi-generator-ignore
-// once the OpenAPI spec references ComputePoolStatus via $ref instead of
-// defining status inline.
+// UnmarshalJSON handles ComputePool.Status when the API returns a flat object
+// (e.g. {"phase":"RUNNING"}). The generated type *map[string]map[string]interface{}
+// cannot hold scalar values directly, so scalars and nulls are wrapped as
+// {"value": v}; object values pass through unchanged. Non-object shapes
+// (array, scalar) yield a nil Status instead of failing the decode.
 func (o *ComputePool) UnmarshalJSON(data []byte) error {
-	// Alias prevents infinite recursion: the aliased type has no methods,
-	// so json.Unmarshal uses reflection-based decoding for the embedded struct.
+	// Alias strips methods so the inner decode doesn't re-enter UnmarshalJSON.
 	type Alias ComputePool
 	aux := struct {
 		Status json.RawMessage `json:"status"`
 		*Alias
-	}{
-		Alias: (*Alias)(o),
-	}
+	}{Alias: (*Alias)(o)}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
 	}
-	// Reset Status so re-used receivers don't retain stale values when the
-	// incoming payload has status null or missing.
-	o.Status = nil
+	o.Status = nil // reset for receiver reuse; repopulated below on success
 	if len(aux.Status) == 0 || bytes.Equal(aux.Status, []byte("null")) {
 		return nil
 	}
-	// The status must decode as a JSON object. Anything else (array, scalar)
-	// is treated as absent.
 	var flat map[string]interface{}
 	if err := json.Unmarshal(aux.Status, &flat); err != nil {
-		return nil
+		return nil // not an object (array/scalar) — treat as absent
 	}
 	wrapped := make(map[string]map[string]interface{}, len(flat))
 	for k, v := range flat {
 		if m, ok := v.(map[string]interface{}); ok {
-			// Value is already an object — matches the declared inner type, pass through.
-			wrapped[k] = m
+			wrapped[k] = m // object — already satisfies declared inner type
 		} else {
-			// Scalar or null — wrap so the result conforms to the declared type.
-			wrapped[k] = map[string]interface{}{"value": v}
+			wrapped[k] = map[string]interface{}{"value": v} // scalar/null — wrap
 		}
 	}
 	o.Status = &wrapped

--- a/v1/model_compute_pool_custom.go
+++ b/v1/model_compute_pool_custom.go
@@ -3,13 +3,14 @@ package v1
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 )
 
 // UnmarshalJSON handles ComputePool.Status when the API returns a flat object
 // (e.g. {"phase":"RUNNING"}). The generated type *map[string]map[string]interface{}
-// cannot hold scalar values directly, so scalars and nulls are wrapped as
-// {"value": v}; object values pass through unchanged. Non-object shapes
-// (array, scalar) yield a nil Status instead of failing the decode.
+// cannot hold scalar values directly, so every value in the status object is
+// wrapped as {"value": v}. Non-object status shapes (array, scalar) surface a
+// decode error rather than being silently dropped.
 func (o *ComputePool) UnmarshalJSON(data []byte) error {
 	// Alias strips methods so the inner decode doesn't re-enter UnmarshalJSON.
 	type Alias ComputePool
@@ -26,15 +27,11 @@ func (o *ComputePool) UnmarshalJSON(data []byte) error {
 	}
 	var flat map[string]interface{}
 	if err := json.Unmarshal(aux.Status, &flat); err != nil {
-		return nil // not an object (array/scalar) — treat as absent
+		return fmt.Errorf("unmarshal ComputePool.Status: %w", err)
 	}
 	wrapped := make(map[string]map[string]interface{}, len(flat))
 	for k, v := range flat {
-		if m, ok := v.(map[string]interface{}); ok {
-			wrapped[k] = m // object — already satisfies declared inner type
-		} else {
-			wrapped[k] = map[string]interface{}{"value": v} // scalar/null — wrap
-		}
+		wrapped[k] = map[string]interface{}{"value": v}
 	}
 	o.Status = &wrapped
 	return nil

--- a/v1/model_compute_pool_custom.go
+++ b/v1/model_compute_pool_custom.go
@@ -1,0 +1,69 @@
+package v1
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// UnmarshalJSON is a custom unmarshaler that makes ComputePool.Status
+// deserialize correctly against the real CMF API response.
+//
+// The generated type declares Status as *map[string]map[string]interface{}
+// (due to an inline OpenAPI schema with additionalProperties: true), but the
+// API returns a flat object like {"phase":"RUNNING","message":null}. The
+// standard encoding/json decode fails on that shape because scalar values
+// cannot fit into map[string]interface{}.
+//
+// To conform to the declared type, each scalar (or null) value in the status
+// object is wrapped as {"value": <value>}; values that are already objects
+// are passed through unchanged to avoid double-wrapping. Callers can then
+// read fields uniformly via pool.GetStatus()["<key>"]["value"] for scalars,
+// or traverse the nested object directly.
+//
+// Status shapes that are neither null nor a JSON object (e.g. an array,
+// string, or number at the top level) are treated as absent — Status is set
+// to nil rather than failing the whole response deserialization, since the
+// whole point of this unmarshaler is to keep Execute() succeeding on valid
+// 200 responses.
+//
+// TODO: remove this file and its entries in v1/.openapi-generator-ignore
+// once the OpenAPI spec references ComputePoolStatus via $ref instead of
+// defining status inline.
+func (o *ComputePool) UnmarshalJSON(data []byte) error {
+	// Alias prevents infinite recursion: the aliased type has no methods,
+	// so json.Unmarshal uses reflection-based decoding for the embedded struct.
+	type Alias ComputePool
+	aux := struct {
+		Status json.RawMessage `json:"status"`
+		*Alias
+	}{
+		Alias: (*Alias)(o),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	// Reset Status so re-used receivers don't retain stale values when the
+	// incoming payload has status null or missing.
+	o.Status = nil
+	if len(aux.Status) == 0 || bytes.Equal(aux.Status, []byte("null")) {
+		return nil
+	}
+	// The status must decode as a JSON object. Anything else (array, scalar)
+	// is treated as absent.
+	var flat map[string]interface{}
+	if err := json.Unmarshal(aux.Status, &flat); err != nil {
+		return nil
+	}
+	wrapped := make(map[string]map[string]interface{}, len(flat))
+	for k, v := range flat {
+		if m, ok := v.(map[string]interface{}); ok {
+			// Value is already an object — matches the declared inner type, pass through.
+			wrapped[k] = m
+		} else {
+			// Scalar or null — wrap so the result conforms to the declared type.
+			wrapped[k] = map[string]interface{}{"value": v}
+		}
+	}
+	o.Status = &wrapped
+	return nil
+}

--- a/v1/model_compute_pool_custom_test.go
+++ b/v1/model_compute_pool_custom_test.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -84,51 +85,6 @@ func TestComputePoolUnmarshal_FlatStatus(t *testing.T) {
 	}
 }
 
-func TestComputePoolUnmarshal_AlreadyNestedStatus(t *testing.T) {
-	// Object values pass through unchanged, including extra keys (no re-wrap).
-	data := makeComputePoolJSON("pool-b", `{"phase":{"value":"PENDING","extra":"meta"}}`)
-
-	var pool ComputePool
-	if err := json.Unmarshal(data, &pool); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	v, ok := wrappedValue(pool, "phase")
-	if !ok {
-		t.Fatal("phase.value missing")
-	}
-	if v != "PENDING" {
-		t.Errorf("phase.value = %v, want %q", v, "PENDING")
-	}
-	if extra := (*pool.Status)["phase"]["extra"]; extra != "meta" {
-		t.Errorf("phase.extra = %v, want %q (passthrough dropped keys)", extra, "meta")
-	}
-}
-
-func TestComputePoolUnmarshal_PartialNestedStatus(t *testing.T) {
-	// Mixed: some values are objects (already wrapped), some are scalars.
-	// The object passes through unchanged; scalars are wrapped. No double-wrapping.
-	data := makeComputePoolJSON("pool-c", `{"phase":{"value":"RUNNING"},"message":"ok"}`)
-
-	var pool ComputePool
-	if err := json.Unmarshal(data, &pool); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	phase, ok := wrappedValue(pool, "phase")
-	if !ok {
-		t.Fatal("phase.value missing")
-	}
-	if phase != "RUNNING" {
-		t.Errorf("phase.value = %v, want %q (not double-wrapped)", phase, "RUNNING")
-	}
-	message, ok := wrappedValue(pool, "message")
-	if !ok {
-		t.Fatal("message.value missing")
-	}
-	if message != "ok" {
-		t.Errorf("message.value = %v, want %q", message, "ok")
-	}
-}
-
 func TestComputePoolUnmarshal_NullStatus(t *testing.T) {
 	data := makeComputePoolJSON("pool-d", `null`)
 
@@ -190,44 +146,30 @@ func TestComputePoolUnmarshal_AllNullValues(t *testing.T) {
 	}
 }
 
-func TestComputePoolUnmarshal_ArrayStatus(t *testing.T) {
-	// Malformed status shape (array). Must NOT return an error; set Status = nil.
-	data := makeComputePoolJSON("pool-h", `[1,2,3]`)
-
-	var pool ComputePool
-	if err := json.Unmarshal(data, &pool); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+// Non-object status shapes (array, top-level scalar) must surface as decode
+// errors rather than be silently dropped — the backend never returns these
+// shapes, so they indicate an API regression worth flagging.
+func TestComputePoolUnmarshal_NonObjectStatusFails(t *testing.T) {
+	cases := []struct {
+		name   string
+		status string
+	}{
+		{"array", `[1,2,3]`},
+		{"string", `"RUNNING"`},
+		{"number", `42`},
 	}
-	if pool.Status != nil {
-		t.Errorf("status = %v, want nil for non-object status", pool.Status)
-	}
-	// Other fields must still populate.
-	if pool.Metadata.Name != "pool-h" {
-		t.Errorf("metadata.name = %q, want %q", pool.Metadata.Name, "pool-h")
-	}
-}
-
-func TestComputePoolUnmarshal_ScalarStringStatus(t *testing.T) {
-	data := makeComputePoolJSON("pool-i", `"RUNNING"`)
-
-	var pool ComputePool
-	if err := json.Unmarshal(data, &pool); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if pool.Status != nil {
-		t.Errorf("status = %v, want nil for scalar status", pool.Status)
-	}
-}
-
-func TestComputePoolUnmarshal_ScalarNumberStatus(t *testing.T) {
-	data := makeComputePoolJSON("pool-j", `42`)
-
-	var pool ComputePool
-	if err := json.Unmarshal(data, &pool); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if pool.Status != nil {
-		t.Errorf("status = %v, want nil for scalar status", pool.Status)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data := makeComputePoolJSON("pool-"+tc.name, tc.status)
+			var pool ComputePool
+			err := json.Unmarshal(data, &pool)
+			if err == nil {
+				t.Fatalf("expected error for %s status, got nil", tc.name)
+			}
+			if !strings.Contains(err.Error(), "ComputePool.Status") {
+				t.Errorf("err = %q, want it to mention ComputePool.Status", err)
+			}
+		})
 	}
 }
 

--- a/v1/model_compute_pool_custom_test.go
+++ b/v1/model_compute_pool_custom_test.go
@@ -85,8 +85,8 @@ func TestComputePoolUnmarshal_FlatStatus(t *testing.T) {
 }
 
 func TestComputePoolUnmarshal_AlreadyNestedStatus(t *testing.T) {
-	// If every value is an object, it is passed through unchanged.
-	data := makeComputePoolJSON("pool-b", `{"phase":{"value":"PENDING"}}`)
+	// Object values pass through unchanged, including extra keys (no re-wrap).
+	data := makeComputePoolJSON("pool-b", `{"phase":{"value":"PENDING","extra":"meta"}}`)
 
 	var pool ComputePool
 	if err := json.Unmarshal(data, &pool); err != nil {
@@ -98,6 +98,9 @@ func TestComputePoolUnmarshal_AlreadyNestedStatus(t *testing.T) {
 	}
 	if v != "PENDING" {
 		t.Errorf("phase.value = %v, want %q", v, "PENDING")
+	}
+	if extra := (*pool.Status)["phase"]["extra"]; extra != "meta" {
+		t.Errorf("phase.extra = %v, want %q (passthrough dropped keys)", extra, "meta")
 	}
 }
 
@@ -301,7 +304,7 @@ func TestComputePoolUnmarshal_EmptyPageItems(t *testing.T) {
 		{"null", `{"items":null}`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-					var page ComputePoolsPage
+			var page ComputePoolsPage
 			if err := json.Unmarshal([]byte(tc.body), &page); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/v1/model_compute_pool_custom_test.go
+++ b/v1/model_compute_pool_custom_test.go
@@ -1,0 +1,325 @@
+package v1
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// makeComputePoolJSON builds a ComputePool JSON payload with the given status literal.
+// The status argument is inserted verbatim (no quoting), so callers pass raw JSON like
+// `"RUNNING"`, `null`, `{"phase":"X"}`, `[]`, or `42`.
+func makeComputePoolJSON(name, statusLiteral string) []byte {
+	if statusLiteral == "" {
+		return []byte(`{
+			"apiVersion": "cmf.confluent.io/v1",
+			"kind": "ComputePool",
+			"metadata": {"name": "` + name + `"},
+			"spec": {"type": "DEDICATED", "clusterSpec": {}}
+		}`)
+	}
+	return []byte(`{
+		"apiVersion": "cmf.confluent.io/v1",
+		"kind": "ComputePool",
+		"metadata": {"name": "` + name + `"},
+		"spec": {"type": "DEDICATED", "clusterSpec": {}},
+		"status": ` + statusLiteral + `
+	}`)
+}
+
+// wrappedValue returns status[key]["value"] and whether both keys were found.
+func wrappedValue(pool ComputePool, key string) (interface{}, bool) {
+	if pool.Status == nil {
+		return nil, false
+	}
+	inner, ok := (*pool.Status)[key]
+	if !ok {
+		return nil, false
+	}
+	v, ok := inner["value"]
+	return v, ok
+}
+
+func TestComputePoolUnmarshal_FlatStatus(t *testing.T) {
+	data := makeComputePoolJSON("pool-a", `{"phase":"RUNNING","message":null,"reason":"x","ready":true}`)
+
+	var pool ComputePool
+	if err := json.Unmarshal(data, &pool); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pool.Metadata.Name != "pool-a" {
+		t.Errorf("metadata.name = %q, want %q", pool.Metadata.Name, "pool-a")
+	}
+	if pool.Spec.Type != "DEDICATED" {
+		t.Errorf("spec.type = %q, want %q", pool.Spec.Type, "DEDICATED")
+	}
+	if pool.Status == nil {
+		t.Fatal("status is nil")
+	}
+	// Verify every flat key got wrapped, not just phase.
+	wantValues := map[string]interface{}{
+		"phase":   "RUNNING",
+		"message": nil,
+		"reason":  "x",
+		"ready":   true,
+	}
+	status := *pool.Status
+	if len(status) != len(wantValues) {
+		t.Errorf("status has %d keys, want %d", len(status), len(wantValues))
+	}
+	for k, want := range wantValues {
+		inner, ok := status[k]
+		if !ok {
+			t.Errorf("status[%q] missing", k)
+			continue
+		}
+		// Literal-assert the wrapper key name to catch format drift.
+		got, hasValue := inner["value"]
+		if !hasValue {
+			t.Errorf("status[%q] missing %q key; got %v", k, "value", inner)
+			continue
+		}
+		if got != want {
+			t.Errorf("status[%q][\"value\"] = %v, want %v", k, got, want)
+		}
+	}
+}
+
+func TestComputePoolUnmarshal_AlreadyNestedStatus(t *testing.T) {
+	// If every value is an object, it is passed through unchanged.
+	data := makeComputePoolJSON("pool-b", `{"phase":{"value":"PENDING"}}`)
+
+	var pool ComputePool
+	if err := json.Unmarshal(data, &pool); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	v, ok := wrappedValue(pool, "phase")
+	if !ok {
+		t.Fatal("phase.value missing")
+	}
+	if v != "PENDING" {
+		t.Errorf("phase.value = %v, want %q", v, "PENDING")
+	}
+}
+
+func TestComputePoolUnmarshal_PartialNestedStatus(t *testing.T) {
+	// Mixed: some values are objects (already wrapped), some are scalars.
+	// The object passes through unchanged; scalars are wrapped. No double-wrapping.
+	data := makeComputePoolJSON("pool-c", `{"phase":{"value":"RUNNING"},"message":"ok"}`)
+
+	var pool ComputePool
+	if err := json.Unmarshal(data, &pool); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	phase, ok := wrappedValue(pool, "phase")
+	if !ok {
+		t.Fatal("phase.value missing")
+	}
+	if phase != "RUNNING" {
+		t.Errorf("phase.value = %v, want %q (not double-wrapped)", phase, "RUNNING")
+	}
+	message, ok := wrappedValue(pool, "message")
+	if !ok {
+		t.Fatal("message.value missing")
+	}
+	if message != "ok" {
+		t.Errorf("message.value = %v, want %q", message, "ok")
+	}
+}
+
+func TestComputePoolUnmarshal_NullStatus(t *testing.T) {
+	data := makeComputePoolJSON("pool-d", `null`)
+
+	var pool ComputePool
+	if err := json.Unmarshal(data, &pool); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pool.Status != nil {
+		t.Errorf("status = %v, want nil", pool.Status)
+	}
+}
+
+func TestComputePoolUnmarshal_MissingStatus(t *testing.T) {
+	data := makeComputePoolJSON("pool-e", "") // no status field at all
+
+	var pool ComputePool
+	if err := json.Unmarshal(data, &pool); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pool.Status != nil {
+		t.Errorf("status = %v, want nil", pool.Status)
+	}
+	if pool.Metadata.Name != "pool-e" {
+		t.Errorf("metadata.name = %q, want %q", pool.Metadata.Name, "pool-e")
+	}
+}
+
+func TestComputePoolUnmarshal_EmptyObjectStatus(t *testing.T) {
+	data := makeComputePoolJSON("pool-f", `{}`)
+
+	var pool ComputePool
+	if err := json.Unmarshal(data, &pool); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pool.Status == nil {
+		t.Fatal("status is nil, want non-nil empty map")
+	}
+	if len(*pool.Status) != 0 {
+		t.Errorf("status has %d keys, want 0", len(*pool.Status))
+	}
+}
+
+func TestComputePoolUnmarshal_AllNullValues(t *testing.T) {
+	data := makeComputePoolJSON("pool-g", `{"phase":null,"message":null}`)
+
+	var pool ComputePool
+	if err := json.Unmarshal(data, &pool); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, k := range []string{"phase", "message"} {
+		v, ok := wrappedValue(pool, k)
+		if !ok {
+			t.Errorf("%s.value missing", k)
+			continue
+		}
+		if v != nil {
+			t.Errorf("%s.value = %v, want nil", k, v)
+		}
+	}
+}
+
+func TestComputePoolUnmarshal_ArrayStatus(t *testing.T) {
+	// Malformed status shape (array). Must NOT return an error; set Status = nil.
+	data := makeComputePoolJSON("pool-h", `[1,2,3]`)
+
+	var pool ComputePool
+	if err := json.Unmarshal(data, &pool); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pool.Status != nil {
+		t.Errorf("status = %v, want nil for non-object status", pool.Status)
+	}
+	// Other fields must still populate.
+	if pool.Metadata.Name != "pool-h" {
+		t.Errorf("metadata.name = %q, want %q", pool.Metadata.Name, "pool-h")
+	}
+}
+
+func TestComputePoolUnmarshal_ScalarStringStatus(t *testing.T) {
+	data := makeComputePoolJSON("pool-i", `"RUNNING"`)
+
+	var pool ComputePool
+	if err := json.Unmarshal(data, &pool); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pool.Status != nil {
+		t.Errorf("status = %v, want nil for scalar status", pool.Status)
+	}
+}
+
+func TestComputePoolUnmarshal_ScalarNumberStatus(t *testing.T) {
+	data := makeComputePoolJSON("pool-j", `42`)
+
+	var pool ComputePool
+	if err := json.Unmarshal(data, &pool); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pool.Status != nil {
+		t.Errorf("status = %v, want nil for scalar status", pool.Status)
+	}
+}
+
+func TestComputePoolUnmarshal_ReceiverReuse(t *testing.T) {
+	// Unmarshal populates Status, then unmarshal a null-status payload into the
+	// same receiver: Status must be reset to nil, not retain the previous value.
+	var pool ComputePool
+	first := makeComputePoolJSON("first", `{"phase":"RUNNING"}`)
+	if err := json.Unmarshal(first, &pool); err != nil {
+		t.Fatalf("first unmarshal: %v", err)
+	}
+	if pool.Status == nil {
+		t.Fatal("status nil after first unmarshal")
+	}
+	second := makeComputePoolJSON("second", `null`)
+	if err := json.Unmarshal(second, &pool); err != nil {
+		t.Fatalf("second unmarshal: %v", err)
+	}
+	if pool.Status != nil {
+		t.Errorf("status = %v after null payload, want nil", pool.Status)
+	}
+}
+
+func TestComputePoolUnmarshal_PageResponse(t *testing.T) {
+	// ComputePoolsPage.Items should invoke our UnmarshalJSON per element.
+	data := []byte(`{
+		"items": [
+			{
+				"apiVersion": "cmf.confluent.io/v1",
+				"kind": "ComputePool",
+				"metadata": {"name": "pool-1"},
+				"spec": {"type": "DEDICATED", "clusterSpec": {}},
+				"status": {"phase": "RUNNING"}
+			},
+			{
+				"apiVersion": "cmf.confluent.io/v1",
+				"kind": "ComputePool",
+				"metadata": {"name": "pool-2"},
+				"spec": {"type": "DEDICATED", "clusterSpec": {}},
+				"status": {"phase": "PENDING"}
+			}
+		]
+	}`)
+
+	var page ComputePoolsPage
+	if err := json.Unmarshal(data, &page); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	items := page.GetItems()
+	if len(items) != 2 {
+		t.Fatalf("got %d items, want 2", len(items))
+	}
+	wantPhases := []string{"RUNNING", "PENDING"}
+	for i, item := range items {
+		v, ok := wrappedValue(item, "phase")
+		if !ok {
+			t.Errorf("item %d: phase.value missing", i)
+			continue
+		}
+		if v != wantPhases[i] {
+			t.Errorf("item %d phase.value = %v, want %q", i, v, wantPhases[i])
+		}
+	}
+}
+
+func TestComputePoolUnmarshal_EmptyPageItems(t *testing.T) {
+	// Empty and missing items must both yield a zero-length slice, not an error.
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"empty", `{"items":[]}`},
+		{"missing", `{}`},
+		{"null", `{"items":null}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+					var page ComputePoolsPage
+			if err := json.Unmarshal([]byte(tc.body), &page); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if n := len(page.GetItems()); n != 0 {
+				t.Errorf("got %d items, want 0", n)
+			}
+		})
+	}
+}
+
+func TestComputePoolUnmarshal_InvalidJSON(t *testing.T) {
+	// Top-level invalid JSON must still surface an error (not silently passed).
+	var pool ComputePool
+	err := json.Unmarshal([]byte(`{not valid json`), &pool)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if _, isSyntax := err.(*json.SyntaxError); !isSyntax {
+		t.Errorf("err type = %T, want *json.SyntaxError", err)
+	}
+}

--- a/v1/model_compute_pool_custom_test.go
+++ b/v1/model_compute_pool_custom_test.go
@@ -6,9 +6,8 @@ import (
 	"testing"
 )
 
-// makeComputePoolJSON builds a ComputePool JSON payload with the given status literal.
-// The status argument is inserted verbatim (no quoting), so callers pass raw JSON like
-// `"RUNNING"`, `null`, `{"phase":"X"}`, `[]`, or `42`.
+// makeComputePoolJSON builds a ComputePool payload. statusLiteral is raw JSON
+// (e.g. `"RUNNING"`, `null`, `{"phase":"X"}`), or "" to omit the status field.
 func makeComputePoolJSON(name, statusLiteral string) []byte {
 	if statusLiteral == "" {
 		return []byte(`{
@@ -27,7 +26,6 @@ func makeComputePoolJSON(name, statusLiteral string) []byte {
 	}`)
 }
 
-// wrappedValue returns status[key]["value"] and whether both keys were found.
 func wrappedValue(pool ComputePool, key string) (interface{}, bool) {
 	if pool.Status == nil {
 		return nil, false
@@ -56,7 +54,6 @@ func TestComputePoolUnmarshal_FlatStatus(t *testing.T) {
 	if pool.Status == nil {
 		t.Fatal("status is nil")
 	}
-	// Verify every flat key got wrapped, not just phase.
 	wantValues := map[string]interface{}{
 		"phase":   "RUNNING",
 		"message": nil,
@@ -73,7 +70,7 @@ func TestComputePoolUnmarshal_FlatStatus(t *testing.T) {
 			t.Errorf("status[%q] missing", k)
 			continue
 		}
-		// Literal-assert the wrapper key name to catch format drift.
+		// Literal "value" key catches format drift.
 		got, hasValue := inner["value"]
 		if !hasValue {
 			t.Errorf("status[%q] missing %q key; got %v", k, "value", inner)
@@ -98,7 +95,7 @@ func TestComputePoolUnmarshal_NullStatus(t *testing.T) {
 }
 
 func TestComputePoolUnmarshal_MissingStatus(t *testing.T) {
-	data := makeComputePoolJSON("pool-e", "") // no status field at all
+	data := makeComputePoolJSON("pool-e", "")
 
 	var pool ComputePool
 	if err := json.Unmarshal(data, &pool); err != nil {
@@ -146,9 +143,7 @@ func TestComputePoolUnmarshal_AllNullValues(t *testing.T) {
 	}
 }
 
-// Non-object status shapes (array, top-level scalar) must surface as decode
-// errors rather than be silently dropped — the backend never returns these
-// shapes, so they indicate an API regression worth flagging.
+// Non-object status shapes indicate API regressions; surface the decode error.
 func TestComputePoolUnmarshal_NonObjectStatusFails(t *testing.T) {
 	cases := []struct {
 		name   string
@@ -173,9 +168,8 @@ func TestComputePoolUnmarshal_NonObjectStatusFails(t *testing.T) {
 	}
 }
 
+// A null payload on a reused receiver must clear Status, not retain the prior value.
 func TestComputePoolUnmarshal_ReceiverReuse(t *testing.T) {
-	// Unmarshal populates Status, then unmarshal a null-status payload into the
-	// same receiver: Status must be reset to nil, not retain the previous value.
 	var pool ComputePool
 	first := makeComputePoolJSON("first", `{"phase":"RUNNING"}`)
 	if err := json.Unmarshal(first, &pool); err != nil {
@@ -193,8 +187,8 @@ func TestComputePoolUnmarshal_ReceiverReuse(t *testing.T) {
 	}
 }
 
+// ComputePoolsPage.Items must invoke our UnmarshalJSON per element.
 func TestComputePoolUnmarshal_PageResponse(t *testing.T) {
-	// ComputePoolsPage.Items should invoke our UnmarshalJSON per element.
 	data := []byte(`{
 		"items": [
 			{
@@ -236,7 +230,6 @@ func TestComputePoolUnmarshal_PageResponse(t *testing.T) {
 }
 
 func TestComputePoolUnmarshal_EmptyPageItems(t *testing.T) {
-	// Empty and missing items must both yield a zero-length slice, not an error.
 	for _, tc := range []struct {
 		name string
 		body string
@@ -258,7 +251,6 @@ func TestComputePoolUnmarshal_EmptyPageItems(t *testing.T) {
 }
 
 func TestComputePoolUnmarshal_InvalidJSON(t *testing.T) {
-	// Top-level invalid JSON must still surface an error (not silently passed).
 	var pool ComputePool
 	err := json.Unmarshal([]byte(`{not valid json`), &pool)
 	if err == nil {


### PR DESCRIPTION
## Description

`ComputePool.Status` is generated as `*map[string]map[string]interface{}` because the OpenAPI spec declares `status` inline with `additionalProperties: true` instead of `$ref`-ing the defined `ComputePoolStatus` schema. The real CMF API returns a flat status like `{"phase":"RUNNING","message":null}`, which cannot deserialize into that nested map type, so `Execute()` fails on every valid 200 response for all ComputePool endpoints — breaking every SDK consumer (CLI, CFK, etc.).

## Changes

Adds a custom `UnmarshalJSON` on `ComputePool` in a new file (`v1/model_compute_pool_custom.go`), protected via `.openapi-generator-ignore` so regeneration won't overwrite it.

Behavior:
- **Every value in `status`** is wrapped as `{"value": v}` to satisfy the declared inner type `map[string]interface{}`.
- **`null` or missing `status`** leaves `Status = nil`.
- **Non-object `status` shapes** (array, top-level scalar) return a decode error — the CMF backend never sends these shapes, so surfacing the error rather than silently dropping it flags API regressions for debugging.
- **Receiver reuse** resets `Status` so stale values don't leak across decodes.

Consumers read fields uniformly via `pool.GetStatus()["<key>"]["value"]`.

## Testing

### Unit tests

All passing in `v1/model_compute_pool_custom_test.go`:
- `FlatStatus` — real API shape, asserts every key gets the `{"value":v}` wrapper
- `NullStatus`, `MissingStatus`, `EmptyObjectStatus`, `AllNullValues`
- `NonObjectStatusFails` — array, top-level string, top-level number all surface an error mentioning `ComputePool.Status`
- `ReceiverReuse` — re-decoding into a populated receiver clears old state
- `PageResponse` + `EmptyPageItems` (empty/missing/null subtests) — ensures the custom method is invoked via `ComputePoolsPage`
- `InvalidJSON` — top-level JSON errors still propagate as `*json.SyntaxError`

### End-to-end verification against a real CMF server

Verified that the SDK fix alone is sufficient — no consumer-side workaround needed. Setup:

- CLI branch with SDK v0.0.6 bumped up
- `replace github.com/confluentinc/cmf-sdk-go => <local path>` pointing at this branch
- Real CMF server at `http://localhost:9090`

```shell
$ confluent flink compute-pool list --url http://localhost:9090 --environment test-env-labels
       Creation Time       |      Name      |   Type    |   Phase
---------------------------+----------------+-----------+------------
  2026-04-20T06:39:47.893Z | test-cp-labels | DEDICATED | DEDICATED

$ confluent flink compute-pool list --url http://localhost:9090 --environment test-env-labels --output json
[
  {
    "apiVersion": "cmf.confluent.io/v1",
    "kind": "ComputePool",
    "metadata": {
      "name": "test-cp-labels",
      "creationTimestamp": "2026-04-20T06:39:47.893Z",
      "uid": "34ec0a07-1efd-4905-a6fa-fcafe51bbcd2",
      "labels": {},
      "annotations": {}
    },
    "spec": {
      "type": "DEDICATED",
      "clusterSpec": {
        "flinkVersion": "v1_19",
        "image": "confluentinc/cp-flink:1.19.1-cp1"
      }
    },
    "status": {
      "phase": "DEDICATED"
    }
  }
]

$ confluent flink compute-pool describe test-cp-labels --url http://localhost:9090 --environment test-env-labels
+---------------+--------------------------+
| Creation Time | 2026-04-20T06:39:47.893Z |
| Name          | test-cp-labels           |
| Type          | DEDICATED                |
| Phase         | DEDICATED                |
+---------------+--------------------------+

$ confluent flink compute-pool describe test-cp-labels --url http://localhost:9090 --environment test-env-labels --output yaml
apiVersion: cmf.confluent.io/v1
kind: ComputePool
metadata:
    name: test-cp-labels
    creationTimestamp: "2026-04-20T06:39:47.893Z"
    uid: 34ec0a07-1efd-4905-a6fa-fcafe51bbcd2
    labels: {}
    annotations: {}
spec:
    type: DEDICATED
    clusterSpec:
        flinkVersion: v1_19
        image: confluentinc/cp-flink:1.19.1-cp1
status:
    phase: DEDICATED
```

CLI flink unit tests also pass: `go test ./internal/flink/... → ok` (coverage unchanged).

## Significant changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
