### PR TITLE
CF-3528 : Update SDK for CMF v2.3.1

### DIFF
--- a/v1/api/openapi.yaml
+++ b/v1/api/openapi.yaml
@@ -5822,12 +5822,20 @@ components:
         labels:
           additionalProperties:
             type: string
-          description: Labels of the Kubernetes cluster.
+          description: |
+            Labels of the Kubernetes cluster. Omit the field (or send
+            null) to leave existing labels unchanged; send an empty
+            object to clear them.
+          nullable: true
           type: object
         annotations:
           additionalProperties:
             type: string
-          description: Annotations of the Kubernetes cluster.
+          description: |
+            Annotations of the Kubernetes cluster. Omit the field (or
+            send null) to leave existing annotations unchanged; send an
+            empty object to clear them.
+          nullable: true
           type: object
       required:
       - name
@@ -6351,7 +6359,7 @@ components:
         spec:
           $ref: '#/components/schemas/ComputePoolSpec'
         status:
-          additionalProperties: true
+          additionalProperties: {}
           description: Status for ComputePool
           properties:
             phase:

--- a/v1/docs/ComputePool.md
+++ b/v1/docs/ComputePool.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **Kind** | **string** | Kind of resource - set to resource type | 
 **Metadata** | [**ComputePoolMetadata**](ComputePoolMetadata.md) |  | 
 **Spec** | [**ComputePoolSpec**](ComputePoolSpec.md) |  | 
-**Status** | Pointer to **map[string]map[string]interface{}** | Status for ComputePool | [optional] 
+**Status** | Pointer to **map[string]interface{}** | Status for ComputePool | [optional] 
 
 ## Methods
 
@@ -111,20 +111,20 @@ SetSpec sets Spec field to given value.
 
 ### GetStatus
 
-`func (o *ComputePool) GetStatus() map[string]map[string]interface{}`
+`func (o *ComputePool) GetStatus() map[string]interface{}`
 
 GetStatus returns the Status field if non-nil, zero value otherwise.
 
 ### GetStatusOk
 
-`func (o *ComputePool) GetStatusOk() (*map[string]map[string]interface{}, bool)`
+`func (o *ComputePool) GetStatusOk() (*map[string]interface{}, bool)`
 
 GetStatusOk returns a tuple with the Status field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetStatus
 
-`func (o *ComputePool) SetStatus(v map[string]map[string]interface{})`
+`func (o *ComputePool) SetStatus(v map[string]interface{})`
 
 SetStatus sets Status field to given value.
 

--- a/v1/docs/ComputePoolAllOf.md
+++ b/v1/docs/ComputePoolAllOf.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Metadata** | [**ComputePoolMetadata**](ComputePoolMetadata.md) |  | 
 **Spec** | [**ComputePoolSpec**](ComputePoolSpec.md) |  | 
-**Status** | Pointer to **map[string]map[string]interface{}** | Status for ComputePool | [optional] 
+**Status** | Pointer to **map[string]interface{}** | Status for ComputePool | [optional] 
 
 ## Methods
 
@@ -69,20 +69,20 @@ SetSpec sets Spec field to given value.
 
 ### GetStatus
 
-`func (o *ComputePoolAllOf) GetStatus() map[string]map[string]interface{}`
+`func (o *ComputePoolAllOf) GetStatus() map[string]interface{}`
 
 GetStatus returns the Status field if non-nil, zero value otherwise.
 
 ### GetStatusOk
 
-`func (o *ComputePoolAllOf) GetStatusOk() (*map[string]map[string]interface{}, bool)`
+`func (o *ComputePoolAllOf) GetStatusOk() (*map[string]interface{}, bool)`
 
 GetStatusOk returns a tuple with the Status field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetStatus
 
-`func (o *ComputePoolAllOf) SetStatus(v map[string]map[string]interface{})`
+`func (o *ComputePoolAllOf) SetStatus(v map[string]interface{})`
 
 SetStatus sets Status field to given value.
 

--- a/v1/docs/KubernetesClusterMetadata.md
+++ b/v1/docs/KubernetesClusterMetadata.md
@@ -8,8 +8,8 @@ Name | Type | Description | Notes
 **CreationTimestamp** | Pointer to **string** | Timestamp when the cluster was registered. | [optional] [readonly] 
 **UpdateTimestamp** | Pointer to **string** | Timestamp when the cluster was last updated. | [optional] [readonly] 
 **Uid** | Pointer to **string** | Unique identifier of the Kubernetes cluster. | [optional] [readonly] 
-**Labels** | Pointer to **map[string]string** | Labels of the Kubernetes cluster. | [optional] 
-**Annotations** | Pointer to **map[string]string** | Annotations of the Kubernetes cluster. | [optional] 
+**Labels** | Pointer to **map[string]string** | Labels of the Kubernetes cluster. Omit the field (or send null) to leave existing labels unchanged; send an empty object to clear them.  | [optional] 
+**Annotations** | Pointer to **map[string]string** | Annotations of the Kubernetes cluster. Omit the field (or send null) to leave existing annotations unchanged; send an empty object to clear them.  | [optional] 
 
 ## Methods
 
@@ -150,6 +150,16 @@ SetLabels sets Labels field to given value.
 
 HasLabels returns a boolean if a field has been set.
 
+### SetLabelsNil
+
+`func (o *KubernetesClusterMetadata) SetLabelsNil(b bool)`
+
+ SetLabelsNil sets the value for Labels to be an explicit nil
+
+### UnsetLabels
+`func (o *KubernetesClusterMetadata) UnsetLabels()`
+
+UnsetLabels ensures that no value is present for Labels, not even an explicit nil
 ### GetAnnotations
 
 `func (o *KubernetesClusterMetadata) GetAnnotations() map[string]string`
@@ -175,6 +185,16 @@ SetAnnotations sets Annotations field to given value.
 
 HasAnnotations returns a boolean if a field has been set.
 
+### SetAnnotationsNil
+
+`func (o *KubernetesClusterMetadata) SetAnnotationsNil(b bool)`
+
+ SetAnnotationsNil sets the value for Annotations to be an explicit nil
+
+### UnsetAnnotations
+`func (o *KubernetesClusterMetadata) UnsetAnnotations()`
+
+UnsetAnnotations ensures that no value is present for Annotations, not even an explicit nil
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/v1/model_compute_pool.go
+++ b/v1/model_compute_pool.go
@@ -23,7 +23,7 @@ type ComputePool struct {
 	Metadata ComputePoolMetadata `json:"metadata"`
 	Spec ComputePoolSpec `json:"spec"`
 	// Status for ComputePool
-	Status *map[string]map[string]interface{} `json:"status,omitempty"`
+	Status *map[string]interface{} `json:"status,omitempty"`
 }
 
 // NewComputePool instantiates a new ComputePool object
@@ -144,9 +144,9 @@ func (o *ComputePool) SetSpec(v ComputePoolSpec) {
 }
 
 // GetStatus returns the Status field value if set, zero value otherwise.
-func (o *ComputePool) GetStatus() map[string]map[string]interface{} {
+func (o *ComputePool) GetStatus() map[string]interface{} {
 	if o == nil || o.Status == nil {
-		var ret map[string]map[string]interface{}
+		var ret map[string]interface{}
 		return ret
 	}
 	return *o.Status
@@ -154,7 +154,7 @@ func (o *ComputePool) GetStatus() map[string]map[string]interface{} {
 
 // GetStatusOk returns a tuple with the Status field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ComputePool) GetStatusOk() (*map[string]map[string]interface{}, bool) {
+func (o *ComputePool) GetStatusOk() (*map[string]interface{}, bool) {
 	if o == nil || o.Status == nil {
 		return nil, false
 	}
@@ -170,8 +170,8 @@ func (o *ComputePool) HasStatus() bool {
 	return false
 }
 
-// SetStatus gets a reference to the given map[string]map[string]interface{} and assigns it to the Status field.
-func (o *ComputePool) SetStatus(v map[string]map[string]interface{}) {
+// SetStatus gets a reference to the given map[string]interface{} and assigns it to the Status field.
+func (o *ComputePool) SetStatus(v map[string]interface{}) {
 	o.Status = &v
 }
 

--- a/v1/model_compute_pool_all_of.go
+++ b/v1/model_compute_pool_all_of.go
@@ -19,7 +19,7 @@ type ComputePoolAllOf struct {
 	Metadata ComputePoolMetadata `json:"metadata"`
 	Spec ComputePoolSpec `json:"spec"`
 	// Status for ComputePool
-	Status *map[string]map[string]interface{} `json:"status,omitempty"`
+	Status *map[string]interface{} `json:"status,omitempty"`
 }
 
 // NewComputePoolAllOf instantiates a new ComputePoolAllOf object
@@ -90,9 +90,9 @@ func (o *ComputePoolAllOf) SetSpec(v ComputePoolSpec) {
 }
 
 // GetStatus returns the Status field value if set, zero value otherwise.
-func (o *ComputePoolAllOf) GetStatus() map[string]map[string]interface{} {
+func (o *ComputePoolAllOf) GetStatus() map[string]interface{} {
 	if o == nil || o.Status == nil {
-		var ret map[string]map[string]interface{}
+		var ret map[string]interface{}
 		return ret
 	}
 	return *o.Status
@@ -100,7 +100,7 @@ func (o *ComputePoolAllOf) GetStatus() map[string]map[string]interface{} {
 
 // GetStatusOk returns a tuple with the Status field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ComputePoolAllOf) GetStatusOk() (*map[string]map[string]interface{}, bool) {
+func (o *ComputePoolAllOf) GetStatusOk() (*map[string]interface{}, bool) {
 	if o == nil || o.Status == nil {
 		return nil, false
 	}
@@ -116,8 +116,8 @@ func (o *ComputePoolAllOf) HasStatus() bool {
 	return false
 }
 
-// SetStatus gets a reference to the given map[string]map[string]interface{} and assigns it to the Status field.
-func (o *ComputePoolAllOf) SetStatus(v map[string]map[string]interface{}) {
+// SetStatus gets a reference to the given map[string]interface{} and assigns it to the Status field.
+func (o *ComputePoolAllOf) SetStatus(v map[string]interface{}) {
 	o.Status = &v
 }
 

--- a/v1/model_kubernetes_cluster_metadata.go
+++ b/v1/model_kubernetes_cluster_metadata.go
@@ -24,10 +24,10 @@ type KubernetesClusterMetadata struct {
 	UpdateTimestamp *string `json:"updateTimestamp,omitempty"`
 	// Unique identifier of the Kubernetes cluster.
 	Uid *string `json:"uid,omitempty"`
-	// Labels of the Kubernetes cluster.
-	Labels *map[string]string `json:"labels,omitempty"`
-	// Annotations of the Kubernetes cluster.
-	Annotations *map[string]string `json:"annotations,omitempty"`
+	// Labels of the Kubernetes cluster. Omit the field (or send null) to leave existing labels unchanged; send an empty object to clear them. 
+	Labels map[string]string `json:"labels,omitempty"`
+	// Annotations of the Kubernetes cluster. Omit the field (or send null) to leave existing annotations unchanged; send an empty object to clear them. 
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // NewKubernetesClusterMetadata instantiates a new KubernetesClusterMetadata object
@@ -168,22 +168,23 @@ func (o *KubernetesClusterMetadata) SetUid(v string) {
 	o.Uid = &v
 }
 
-// GetLabels returns the Labels field value if set, zero value otherwise.
+// GetLabels returns the Labels field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *KubernetesClusterMetadata) GetLabels() map[string]string {
-	if o == nil || o.Labels == nil {
+	if o == nil  {
 		var ret map[string]string
 		return ret
 	}
-	return *o.Labels
+	return o.Labels
 }
 
 // GetLabelsOk returns a tuple with the Labels field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *KubernetesClusterMetadata) GetLabelsOk() (*map[string]string, bool) {
 	if o == nil || o.Labels == nil {
 		return nil, false
 	}
-	return o.Labels, true
+	return &o.Labels, true
 }
 
 // HasLabels returns a boolean if a field has been set.
@@ -197,25 +198,26 @@ func (o *KubernetesClusterMetadata) HasLabels() bool {
 
 // SetLabels gets a reference to the given map[string]string and assigns it to the Labels field.
 func (o *KubernetesClusterMetadata) SetLabels(v map[string]string) {
-	o.Labels = &v
+	o.Labels = v
 }
 
-// GetAnnotations returns the Annotations field value if set, zero value otherwise.
+// GetAnnotations returns the Annotations field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *KubernetesClusterMetadata) GetAnnotations() map[string]string {
-	if o == nil || o.Annotations == nil {
+	if o == nil  {
 		var ret map[string]string
 		return ret
 	}
-	return *o.Annotations
+	return o.Annotations
 }
 
 // GetAnnotationsOk returns a tuple with the Annotations field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *KubernetesClusterMetadata) GetAnnotationsOk() (*map[string]string, bool) {
 	if o == nil || o.Annotations == nil {
 		return nil, false
 	}
-	return o.Annotations, true
+	return &o.Annotations, true
 }
 
 // HasAnnotations returns a boolean if a field has been set.
@@ -229,7 +231,7 @@ func (o *KubernetesClusterMetadata) HasAnnotations() bool {
 
 // SetAnnotations gets a reference to the given map[string]string and assigns it to the Annotations field.
 func (o *KubernetesClusterMetadata) SetAnnotations(v map[string]string) {
-	o.Annotations = &v
+	o.Annotations = v
 }
 
 func (o KubernetesClusterMetadata) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
Regenerated via cmf-app/scripts/generate.sh against cp-flink-cmf@main (openapi-generator 5.2.1). Picks up:

1. ComputePool.status decode fix (confluentinc/cp-flink-cmf#1306): Status Go type changes from *map[string]map[string]interface{} to *map[string]interface{}, which lets the default JSON decoder handle the flat-scalar status shape CMF actually returns.

2. KubernetesClusterMetadata Labels/Annotations semantics (confluentinc/cp-flink-cmf#1277): fields change from *map[string]string to map[string]string.

3. Doc-comment refreshes across api_sql.go, api_environments.go, api_flink_applications.go, api_detached_savepoints.go, and their corresponding docs pages.

End-to-end verified: CLI built against this SDK exercised all on-prem compute-pool commands (list/describe/create in human/json/yaml + delete) against a real CMF server — 10/10 pass.

Ticket: CF-3528

## Description

## Changes

## Testing

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update