### PR TITLE
fix(service.yml): disable make plugin (forbidden on public repos)

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -6,7 +6,7 @@ git:
 github:
   enable: true
 make:
-  enable: true
+  enable: false
   enable_updates: true
 codeowners:
   enable: true


### PR DESCRIPTION
## Why
The cc-service-bot nightly run ([job 7c09131f](https://semaphore.ci.confluent.io/jobs/7c09131f-626d-46e1-94dd-bda46c23e361), 2026-05-28) failed for this repo:

> Invalid service-bot manifest for 'make.enable': must not be enabled for public repos

cc-service-bot does not allow the `make` plugin on public repositories (it would manage/expose internal cc-mk-include). This repo is public, so the plugin can never run and the nightly errors out.

## Change
Set `make.enable: false` so service-bot skips the make plugin and processes the rest of the manifest cleanly.

## Safety
Draft PR for the owning team to review. If this repo genuinely needs service-bot-managed Makefile/mk-include, it must be private instead. Part of a sweep fixing the service-bot nightly; systemic validation regressions affecting ~262 other repos are fixed in confluentinc/cc-service-bot#2030.
